### PR TITLE
Fix CI: update RubyGems for ffi compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,12 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.8'
-          bundler-cache: true
+
+      - name: Update RubyGems
+        run: gem update --system 3.4.22
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Build site
         run: bundle exec middleman build


### PR DESCRIPTION
## Summary
- Ruby 2.7.8 ships with RubyGems 3.1.6, but the `ffi` gem (v1.17.2) requires RubyGems >= 3.3.22
- Adds an explicit `gem update --system 3.4.22` step before `bundle install` in the GitHub Actions workflow

## Test plan
- [ ] GitHub Actions workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)