### PR TITLE
Fix CI: pin Node.js 16 for autoprefixer compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.8'


### PR DESCRIPTION
## Summary
- `autoprefixer-rails 9.8.x` bundles JS that errors on Node.js 18+ with `Cannot read properties of undefined (reading 'version')`
- Pins Node.js 16 in the workflow to fix CSS build step

## Test plan
- [ ] GitHub Actions workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)