### PR TITLE
Remove deprecated autoprefixer-rails to fix CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '16'
-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.8'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 # Works with Ruby 2.7.8
 
 gem 'middleman', '~> 4.6'
-gem 'middleman-autoprefixer', '~> 2.7'
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby, :x64_mingw]
 gem 'wdm', '~> 0.1', platforms: [:mswin, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,6 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    autoprefixer-rails (9.8.6.5)
-      execjs
     base64 (0.2.0)
     bigdecimal (3.1.9)
     coffee-script (2.4.1)
@@ -49,9 +47,6 @@ GEM
     middleman (4.6.0)
       middleman-cli (= 4.6.0)
       middleman-core (= 4.6.0)
-    middleman-autoprefixer (2.10.1)
-      autoprefixer-rails (~> 9.1)
-      middleman-core (>= 3.3.3)
     middleman-cli (4.6.0)
       thor (>= 0.17.0, < 1.3.0)
     middleman-core (4.6.0)
@@ -128,7 +123,6 @@ PLATFORMS
 
 DEPENDENCIES
   middleman (~> 4.6)
-  middleman-autoprefixer (~> 2.7)
   tzinfo-data
   wdm (~> 0.1)
 

--- a/config.rb
+++ b/config.rb
@@ -3,10 +3,6 @@
 
 set :relative_links, true
 
-activate :autoprefixer do |prefix|
-  prefix.browsers = "last 2 versions"
-end
-
 # Layouts
 # https://middlemanapp.com/basics/layouts/
 


### PR DESCRIPTION
## Summary
- `autoprefixer-rails 9.8.x` bundles JS incompatible with modern Node.js, causing CSS build errors
- The gem is deprecated and modern browsers no longer need vendor prefixes
- Removes `middleman-autoprefixer` from Gemfile, its config from `config.rb`, and the Node.js setup step from CI

## Test plan
- [x] `bundle exec middleman build` succeeds locally
- [ ] GitHub Actions workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)